### PR TITLE
Internet Explorer 9′s problematic console object

### DIFF
--- a/client/thunderpush.js
+++ b/client/thunderpush.js
@@ -1,3 +1,4 @@
+var isMSIE = /*@cc_on!@*/0;
 var Thunder = new function() {
     this.channels = [];
     this.handlers = [];
@@ -97,8 +98,12 @@ var Thunder = new function() {
                 console.log(arguments[0]);
             }
             else {
-                console.log.apply(console, 
-                    Array.prototype.slice.call(arguments));
+                if (isMSIE) {
+                    var log = Function.prototype.bind.call(console.log, console);
+                    log.apply(console, Array.prototype.slice.call(arguments));
+                } else {
+                    console.log.apply(console, Array.prototype.slice.call(arguments));
+                }
             }
         }
     };


### PR DESCRIPTION
tried to use console.log.apply, I got an error. After some quick
investigations, it appeared obvious that the console object being
injected into the window by the developer tools hadn’t received an
update since Internet Explorer 8 and so the methods it contains aren’t
instances of Function like all the most other DOM methods.
